### PR TITLE
fix: correct inverted After/Before/NotAfter/NotBefore condition semantics

### DIFF
--- a/src/Pure.Primitives.Date.Operations/AfterCondition.cs
+++ b/src/Pure.Primitives.Date.Operations/AfterCondition.cs
@@ -27,11 +27,11 @@ public sealed record AfterCondition : IBool
                 x.Day.NumberValue
             ));
 
-            DateOnly prev = DateOnly.MaxValue;
+            DateOnly prev = DateOnly.MinValue;
 
             foreach (DateOnly date in dates)
             {
-                if (prev <= date)
+                if (prev >= date)
                 {
                     return false;
                 }

--- a/src/Pure.Primitives.Date.Operations/BeforeCondition.cs
+++ b/src/Pure.Primitives.Date.Operations/BeforeCondition.cs
@@ -27,11 +27,11 @@ public sealed record BeforeCondition : IBool
                 x.Day.NumberValue
             ));
 
-            DateOnly prev = DateOnly.MinValue;
+            DateOnly prev = DateOnly.MaxValue;
 
             foreach (DateOnly date in dates)
             {
-                if (prev >= date)
+                if (prev <= date)
                 {
                     return false;
                 }

--- a/src/Pure.Primitives.Date.Operations/NotAfterCondition.cs
+++ b/src/Pure.Primitives.Date.Operations/NotAfterCondition.cs
@@ -27,11 +27,11 @@ public sealed record NotAfterCondition : IBool
                 x.Day.NumberValue
             ));
 
-            DateOnly prev = DateOnly.MinValue;
+            DateOnly prev = DateOnly.MaxValue;
 
             foreach (DateOnly date in dates)
             {
-                if (prev > date)
+                if (prev < date)
                 {
                     return false;
                 }

--- a/src/Pure.Primitives.Date.Operations/NotBeforeCondition.cs
+++ b/src/Pure.Primitives.Date.Operations/NotBeforeCondition.cs
@@ -27,11 +27,11 @@ public sealed record NotBeforeCondition : IBool
                 x.Day.NumberValue
             ));
 
-            DateOnly prev = DateOnly.MaxValue;
+            DateOnly prev = DateOnly.MinValue;
 
             foreach (DateOnly date in dates)
             {
-                if (prev < date)
+                if (prev > date)
                 {
                     return false;
                 }

--- a/src/Tests/Pure.Primitives.Date.Operations.Tests/AfterConditionTests.cs
+++ b/src/Tests/Pure.Primitives.Date.Operations.Tests/AfterConditionTests.cs
@@ -30,9 +30,9 @@ public sealed record AfterConditionTests
         IEnumerable<IDate> randomDates = new RandomDateCollection(new UShort(1000))
             .Select(x => new MaterializedDate(x).Value)
             .Distinct()
-            .OrderByDescending(x => x.Year)
-            .ThenByDescending(x => x.Month)
-            .ThenByDescending(x => x.Day)
+            .OrderBy(x => x.Year)
+            .ThenBy(x => x.Month)
+            .ThenBy(x => x.Day)
             .Select(x => new Date(x));
 
         IBool isAfter = new AfterCondition(randomDates);
@@ -60,7 +60,7 @@ public sealed record AfterConditionTests
             new Date(new UShort(1), new UShort(3), new UShort(2002))
         );
 
-        Assert.False(isGreaterThan.BoolValue);
+        Assert.True(isGreaterThan.BoolValue);
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public sealed record AfterConditionTests
             new Date(new UShort(3), new UShort(1), new UShort(2002))
         );
 
-        Assert.False(isGreaterThan.BoolValue);
+        Assert.True(isGreaterThan.BoolValue);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public sealed record AfterConditionTests
             new Date(new UShort(3), new UShort(3), new UShort(2000))
         );
 
-        Assert.True(isGreaterThan.BoolValue);
+        Assert.False(isGreaterThan.BoolValue);
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public sealed record AfterConditionTests
             new Date(new UShort(3), month, year)
         );
 
-        Assert.False(isGreaterThan.BoolValue);
+        Assert.True(isGreaterThan.BoolValue);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public sealed record AfterConditionTests
             new Date(new UShort(1), new UShort(3), year)
         );
 
-        Assert.False(isGreaterThan.BoolValue);
+        Assert.True(isGreaterThan.BoolValue);
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public sealed record AfterConditionTests
             new Date(new UShort(1), new UShort(1), new UShort(2002))
         );
 
-        Assert.False(isGreaterThan.BoolValue);
+        Assert.True(isGreaterThan.BoolValue);
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public sealed record AfterConditionTests
             new Date(new UShort(1), month, year)
         );
 
-        Assert.True(isGreaterThan.BoolValue);
+        Assert.False(isGreaterThan.BoolValue);
     }
 
     [Fact]
@@ -154,7 +154,7 @@ public sealed record AfterConditionTests
             new Date(new UShort(1), new UShort(1), year)
         );
 
-        Assert.True(isGreaterThan.BoolValue);
+        Assert.False(isGreaterThan.BoolValue);
     }
 
     [Fact]
@@ -166,7 +166,7 @@ public sealed record AfterConditionTests
             new Date(new UShort(1), new UShort(1), new UShort(2001))
         );
 
-        Assert.True(isGreaterThan.BoolValue);
+        Assert.False(isGreaterThan.BoolValue);
     }
 
     [Fact]

--- a/src/Tests/Pure.Primitives.Date.Operations.Tests/BeforeConditionTests.cs
+++ b/src/Tests/Pure.Primitives.Date.Operations.Tests/BeforeConditionTests.cs
@@ -30,9 +30,9 @@ public sealed record BeforeConditionTests
         IEnumerable<IDate> randomDates = new RandomDateCollection(new UShort(1000))
             .Select(x => new MaterializedDate(x).Value)
             .Distinct()
-            .OrderBy(x => x.Year)
-            .ThenBy(x => x.Month)
-            .ThenBy(x => x.Day)
+            .OrderByDescending(x => x.Year)
+            .ThenByDescending(x => x.Month)
+            .ThenByDescending(x => x.Day)
             .Select(x => new Date(x));
 
         IBool before = new BeforeCondition(randomDates);
@@ -60,7 +60,7 @@ public sealed record BeforeConditionTests
             new Date(new UShort(1), new UShort(3), new UShort(2002))
         );
 
-        Assert.True(before.BoolValue);
+        Assert.False(before.BoolValue);
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public sealed record BeforeConditionTests
             new Date(new UShort(3), new UShort(1), new UShort(2002))
         );
 
-        Assert.True(before.BoolValue);
+        Assert.False(before.BoolValue);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public sealed record BeforeConditionTests
             new Date(new UShort(3), new UShort(3), new UShort(2000))
         );
 
-        Assert.False(isBeforeCondition.BoolValue);
+        Assert.True(isBeforeCondition.BoolValue);
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public sealed record BeforeConditionTests
             new Date(new UShort(3), month, year)
         );
 
-        Assert.True(isBeforeCondition.BoolValue);
+        Assert.False(isBeforeCondition.BoolValue);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public sealed record BeforeConditionTests
             new Date(new UShort(1), new UShort(3), year)
         );
 
-        Assert.True(isBeforeCondition.BoolValue);
+        Assert.False(isBeforeCondition.BoolValue);
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public sealed record BeforeConditionTests
             new Date(new UShort(1), new UShort(1), new UShort(2002))
         );
 
-        Assert.True(isBeforeCondition.BoolValue);
+        Assert.False(isBeforeCondition.BoolValue);
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public sealed record BeforeConditionTests
             new Date(new UShort(1), month, year)
         );
 
-        Assert.False(isBeforeCondition.BoolValue);
+        Assert.True(isBeforeCondition.BoolValue);
     }
 
     [Fact]
@@ -154,7 +154,7 @@ public sealed record BeforeConditionTests
             new Date(new UShort(1), new UShort(1), year)
         );
 
-        Assert.False(isBeforeCondition.BoolValue);
+        Assert.True(isBeforeCondition.BoolValue);
     }
 
     [Fact]
@@ -166,7 +166,7 @@ public sealed record BeforeConditionTests
             new Date(new UShort(1), new UShort(1), new UShort(2001))
         );
 
-        Assert.False(isBeforeCondition.BoolValue);
+        Assert.True(isBeforeCondition.BoolValue);
     }
 
     [Fact]

--- a/src/Tests/Pure.Primitives.Date.Operations.Tests/NotAfterConditionTests.cs
+++ b/src/Tests/Pure.Primitives.Date.Operations.Tests/NotAfterConditionTests.cs
@@ -29,9 +29,9 @@ public sealed record NotAfterConditionTests
     {
         IEnumerable<IDate> randomDates = new RandomDateCollection(new UShort(1000))
             .Select(x => new MaterializedDate(x).Value)
-            .OrderBy(x => x.Year)
-            .ThenBy(x => x.Month)
-            .ThenBy(x => x.Day)
+            .OrderByDescending(x => x.Year)
+            .ThenByDescending(x => x.Month)
+            .ThenByDescending(x => x.Day)
             .Select(x => new Date(x));
 
         IBool condition = new NotAfterCondition(randomDates);
@@ -60,7 +60,7 @@ public sealed record NotAfterConditionTests
             new Date(new UShort(1), new UShort(1), new UShort(2002))
         );
 
-        Assert.True(condition.BoolValue);
+        Assert.False(condition.BoolValue);
     }
 
     [Fact]

--- a/src/Tests/Pure.Primitives.Date.Operations.Tests/NotBeforeConditionTests.cs
+++ b/src/Tests/Pure.Primitives.Date.Operations.Tests/NotBeforeConditionTests.cs
@@ -29,9 +29,9 @@ public sealed record NotBeforeConditionTests
     {
         IEnumerable<IDate> randomDates = new RandomDateCollection(new UShort(1000))
             .Select(x => new MaterializedDate(x).Value)
-            .OrderByDescending(x => x.Year)
-            .ThenByDescending(x => x.Month)
-            .ThenByDescending(x => x.Day)
+            .OrderBy(x => x.Year)
+            .ThenBy(x => x.Month)
+            .ThenBy(x => x.Day)
             .Select(x => new Date(x));
 
         IBool condition = new NotBeforeCondition(randomDates);
@@ -60,7 +60,7 @@ public sealed record NotBeforeConditionTests
             new Date(new UShort(1), new UShort(1), new UShort(2002))
         );
 
-        Assert.False(condition.BoolValue);
+        Assert.True(condition.BoolValue);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #135.

All four conditions used inverted logic — `AfterCondition` checked descending order while `BeforeCondition` checked ascending. Corrected to match the semantics in `Pure.Primitives.Time.Operations` and `Pure.Primitives.DateTime.Operations`. Updated tests accordingly.
