### PR TITLE
Update package validation baseline to 1.0.0

### DIFF
--- a/src/Pure.Primitives.Date.Operations/Pure.Primitives.Date.Operations.csproj
+++ b/src/Pure.Primitives.Date.Operations/Pure.Primitives.Date.Operations.csproj
@@ -7,7 +7,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <PublishAot>true</PublishAot>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.3.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Primitives.Date.Operations</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.3.1` to `1.0.0` following the successful publish.