### PR TITLE
Update docs references to 1.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ All condition types accept `params IEnumerable<IDate>` and throw `ArgumentExcept
 
 **Multi-targeting:** net7.0, net8.0, net9.0, net10.0. All types must remain AOT-compatible (`IsAotCompatible = true`, `PublishAot = true`).
 
-**Package validation:** `EnablePackageValidation = true` with `PackageValidationBaselineVersion = 0.3.1`. Breaking API changes fail the build.
+**Package validation:** `EnablePackageValidation = true` with `PackageValidationBaselineVersion = 1.0.0`. Breaking API changes fail the build.
 
 **Publishing:** triggered by pushing a semver tag (`*.*.*`). The tag becomes the `PackageVersion` passed to `dotnet pack`.
 


### PR DESCRIPTION
Update hard-coded version references in documentation from `0.3.1` to `1.0.0` following the release.

## Files updated
- CLAUDE.md